### PR TITLE
Fixed compile error when cross-compiling

### DIFF
--- a/01-tar-instead-of-zip.patch
+++ b/01-tar-instead-of-zip.patch
@@ -9,8 +9,10 @@ index 314f4fe6..9adc2d39 100755
 -GEMMLOWP_URL="$(grep -o 'https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/gemmlowp/.*zip' "${BZL_FILE_PATH}" | head -n1)"
 +GEMMLOWP_URL="$(grep -o 'https://github.com/google/gemmlowp/.*tar.gz' "${BZL_FILE_PATH}" | head -n1)"
  GEMMLOWP_SHA="$(eval echo $(grep '# SHARED_GEMMLOWP_SHA' "${BZL_FILE_PATH}" | grep -o '\".*\"'))"
- RUY_URL="https://github.com/google/ruy/archive/91d62808498cea7ccb48aa59181e218b4ad05701.zip"
- RUY_SHA="ac6d71df496a20043252f451d82a01636bb8bba9c3d6b5dc9fadadaffa392751"
+-RUY_URL="https://github.com/google/ruy/archive/91d62808498cea7ccb48aa59181e218b4ad05701.zip"
++RUY_URL="https://github.com/google/ruy/archive/91d62808498cea7ccb48aa59181e218b4ad05701.tar.gz"
+-RUY_SHA="ac6d71df496a20043252f451d82a01636bb8bba9c3d6b5dc9fadadaffa392751"
++RUY_SHA="7dacab205dfb93d761f2197c43a02b56b820dc1d66d173df19d0e9cda9757aa6"
 @@ -43,13 +43,13 @@ GOOGLETEST_URL="https://github.com/google/googletest/archive/release-1.8.0.tar.g
  GOOGLETEST_SHA="58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8"
  ABSL_URL="$(grep -o 'https://github.com/abseil/abseil-cpp/.*tar.gz' "${BZL_FILE_PATH}" | head -n1)"


### PR DESCRIPTION
Had to convert another zip file to tar.gz to address missing unzip in cross-compilation docker.
I believe I didn't get this error before as previously I conan installed the OSX version first which triggered the source code download (and unziped dependencies). When building for arm, it used the available source instead of re-downloading it.